### PR TITLE
Added card::esp_serial() method to get ESP unique ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 log.txt
 rfid-arduino.code-workspace
 secrets.hpp
+tools/__pycache__/

--- a/include/card.hpp
+++ b/include/card.hpp
@@ -59,5 +59,19 @@ namespace fablabbg::card
   {
     ESP_LOGI(TAG, "Card UID = %s", card::uid_str(uid).c_str());
   }
+
+  /// @brief Returns the ESP32 serial number as a string
+  inline auto esp_serial() -> std::string
+  {
+    std::stringstream serial{};
+    std::array<uint8_t, 8> mac{0};
+
+    esp_efuse_mac_get_default(mac.data());
+    for (const auto val : mac)
+    {
+      serial << std::setfill('0') << std::setw(2) << std::hex << +val;
+    }
+    return serial.str().substr(0U, 6 * 2);
+  }
 } // namespace fablabbg::card
 #endif // CARD_HPP_

--- a/src/FabBackend.cpp
+++ b/src/FabBackend.cpp
@@ -196,6 +196,8 @@ namespace fablabbg
     // Connect WiFi if needed
     if (WiFi.status() != WL_CONNECTED)
     {
+      WiFi.setAutoReconnect(true);
+      WiFi.persistent(true);
       WiFi.mode(WIFI_STA);
       ESP_LOGD(TAG, "FabServer::connectWiFi() : WiFi connection state=%d, connecting to SSID:%s (channel:%d)", WiFi.status(), wifi_ssid.c_str(), channel);
       WiFi.begin(wifi_ssid.data(), wifi_password.data(), channel);

--- a/src/MQTTtypes.cpp
+++ b/src/MQTTtypes.cpp
@@ -38,20 +38,12 @@ namespace fablabbg::ServerMQTT
     std::stringstream ss{};
 
     // Get MAC address
-
-    std::array<uint8_t, 8> mac{0};
-    esp_efuse_mac_get_default(mac.data());
-
-    std::stringstream serial{};
-    for (const auto val : mac)
-    {
-      serial << std::setfill('0') << std::setw(2) << std::hex << +val;
-    }
+    auto serial = card::esp_serial();
 
     ss << "{\"action\":\"alive\","
        << "\"version\":\"" << GIT_VERSION << "\","
        << "\"ip\":\"" << WiFi.localIP().toString().c_str() << "\","
-       << "\"serial\":\"" << serial.str().substr(0U, 6 * 2) << "\","
+       << "\"serial\":\"" << serial << "\","
        << "\"heap\":\"" << esp_get_free_heap_size() << "\""
        << "}";
     return ss.str();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,15 @@ namespace fablabbg
   void taskFactoryReset()
   {
     if constexpr (pins.buttons.factory_defaults_pin == NO_PIN)
+    {
       return;
+    }
+
+    // Skip factory reset for this specific board because Factory Reset is soldered under the MCU with reset pin.
+    if (auto serial = card::esp_serial(); serial == "dcda0c419794")
+    {
+      return;
+    }
 
     pinMode(pins.buttons.factory_defaults_pin, INPUT_PULLUP);
 
@@ -367,7 +375,7 @@ namespace fablabbg
 
     if (disable_portal || config.disablePortal)
     {
-      wifiManager.setDisableConfigPortal(true);
+      wifiManager.setTimeout(1);
     }
 
     if (wifiManager.autoConnect())


### PR DESCRIPTION
fixed loop of portal reset for board rev 0.2
fixed misunderstood method wifiManager.setDisableConfigPortal(true);